### PR TITLE
refactor: Remove default URL values and subdomain fallbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiterone-mcp",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Model Context Protocol server for JupiterOne account rules and rule details",
   "main": "dist/index.js",
   "bin": {

--- a/src/client/services/dashboard-service.ts
+++ b/src/client/services/dashboard-service.ts
@@ -21,9 +21,11 @@ export class DashboardService {
    * Construct dashboard URL based on subdomain
    */
   constructDashboardUrl(dashboardId: string, subdomain?: string): string {
-    // Default to 'j1' if no subdomain provided
-    const accountSubdomain = subdomain || 'j1';
-    return `https://${accountSubdomain}.apps.${getEnv()}.jupiterone.io/insights/dashboards/${dashboardId}`;
+    const environment = getEnv();
+    if (!subdomain || !environment) {
+      return '';
+    }
+    return `https://${subdomain}.apps.${environment}.jupiterone.io/insights/dashboards/${dashboardId}`;
   }
 
   /**

--- a/src/client/services/rule-service.ts
+++ b/src/client/services/rule-service.ts
@@ -38,9 +38,11 @@ export class RuleService {
    * Construct rule URL based on subdomain
    */
   constructRuleUrl(ruleId: string, subdomain?: string): string {
-    // Default to 'j1' if no subdomain provided
-    const accountSubdomain = subdomain || 'j1';
-    return `https://${accountSubdomain}.apps.${getEnv()}.jupiterone.io/alerts/rules/${ruleId}`;
+    const environment = getEnv();
+    if (!subdomain || !environment) {
+      return '';
+    }
+    return `https://${subdomain}.apps.${environment}.jupiterone.io/alerts/rules/${ruleId}`;
   }
 
   /**

--- a/src/utils/getEnv.ts
+++ b/src/utils/getEnv.ts
@@ -1,10 +1,12 @@
 export const getEnv = () => {
   try {
-    const baseUrl = process.env.JUPITERONE_BASE_URL || 'https://graphql.dev.jupiterone.io';
-    const env = baseUrl.split('graphql.')[1].split('.')[0];
-    return env || 'us';
+    const baseUrl = process.env.JUPITERONE_BASE_URL;
+    if (!baseUrl) {
+      return undefined;
+    }
+    const env = baseUrl.split('graphql.')[1]?.split('.')[0];
+    return env || undefined;
   } catch (error) {
-    console.error('Error getting environment:', error);
-    return 'us';
+    return undefined;
   }
 };


### PR DESCRIPTION
- Update getEnv() to return undefined instead of defaulting to 'us'
- Remove default 'j1' subdomain in constructRuleUrl and constructDashboardUrl
- Return empty string when subdomain or environment is missing
- Remove hardcoded default base URL in getEnv

🤖 Generated with [Claude Code](https://claude.ai/code)