### PR TITLE
Auto update remote mcp server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,3 +39,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         run: npm publish --access public
+
+      - name: Trigger remote-mcp deployment
+        if: steps.pkg.outputs.version != steps.published.outputs.published_version
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: JupiterOne/jupiterone-remote-mcp
+          event-type: npm-package-published
+          client-payload: '{"package": "@jupiterone/jupiterone-mcp", "version": "${{ steps.pkg.outputs.version }}"}'

--- a/README.md
+++ b/README.md
@@ -181,3 +181,9 @@ Replace the placeholder values with your actual JupiterOne credentials:
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | `execute-j1ql-query` | Execute a J1QL query | `query`, `variables` (optional), `cursor` (optional), `includeDeleted` (optional), `deferredResponse` (optional), `flags` (optional), `scopeFilters` (optional) |
+
+## Deployment
+
+This package is automatically published to npm when changes are merged to the main branch. The JupiterOne Remote MCP server is configured to automatically deploy when patch versions (e.g., 0.0.8 → 0.0.9) are published.
+
+**Note**: Minor and major version updates (e.g., 0.0.x → 0.1.0 or 0.x.x → 1.0.0) require manual updates to the Remote MCP server's dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiterone-mcp",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Model Context Protocol server for JupiterOne account rules and rule details",
   "main": "dist/index.js",
   "bin": {

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -248,6 +248,10 @@ export class JupiterOneMcpServer {
         try {
           const isConnected = await client.testConnection();
           const accountInfo = isConnected ? await client.getAccountInfo() : null;
+          
+          // Get package version
+          const packageJson = require('../../package.json');
+          const version = packageJson.version;
 
           return {
             content: [
@@ -257,6 +261,7 @@ export class JupiterOneMcpServer {
                   {
                     connected: isConnected,
                     account: accountInfo,
+                    version: version,
                   },
                   null,
                   2


### PR DESCRIPTION
- Include current package version (0.0.9) in test-connection response
- Update deployment workflow to trigger remote MCP auto-deployment
- Document deployment automation in README
- Bump version to 0.0.9 for release
