### PR TITLE
chore: migrate CODEOWNERS to @jupiterone/core-services

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @jupiterone/apps
+* @jupiterone/core-services
 
 CODEOWNERS @jupiterone/security

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
 * @jupiterone/core-services
 
 CODEOWNERS @jupiterone/security
+
+


### PR DESCRIPTION
## Summary
- Updates CODEOWNERS to use @jupiterone/core-services instead of @jupiterone/apps

## Related
- CS-128